### PR TITLE
added return statement to addUser mutation so token is accessible

### DIFF
--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -118,6 +118,7 @@ const resolvers = {
       const user = await User.create(args);
       const token = signToken(user);
 
+      return { token, user };
     },
     login: async (parent, { email, password }) => {
       const user = await User.findOne({ email });


### PR DESCRIPTION
Login/create user issue --
- user is being created/exists, but not retrieving the user info (confirmed bc error message about duplicate email addresses) 
- return statement with token and user was missing the from addUser mutation in the resolvers files

tested successfully in Apollo Studio